### PR TITLE
Better paragraph white space rendering

### DIFF
--- a/scripts/renderer.js
+++ b/scripts/renderer.js
@@ -183,7 +183,7 @@ var render = function (post) {
                 $node.css('color', getColorFromArray(object['color']));
                 $node.css('box-sizing', 'border-box');
                 $node.css('text-align', object['alignment'] || 'left');
-                $node.html(object['text'].replace(/(?:\r\n|\r|\n)/g, '<br>'));
+                $node.css('white-space', 'pre-wrap');
                 break;
 
             case 'video':


### PR DESCRIPTION
Render paragraph with `white-space: pre-wrap` instead of replacing new lines with `<br>`. This allows for paragraphs like this to render like they do in the native app:

```
Hello     notice    how   many spaces

i

have    put
in here!
```
